### PR TITLE
Added the ability to change and then reset the ios master volume

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,5 +32,15 @@
     	<source-file src="src/ios/VolumeSlider.m" />
  		<framework src="MediaPlayer.framework" weak="true" />
     </platform>
+    
+    <!-- android -->
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+			<feature name="VolumeSlider">
+		        <param name="android-package" value="org.devgeeks.volumeslider.VolumeSlider" />
+		    </feature>
+        </config-file>
 
+        <source-file src="src/android/VolumeSlider.java" target-dir="src/org/devgeeks/volumeslider" />
+    </platform>
 </plugin>

--- a/src/android/VolumeSlider.java
+++ b/src/android/VolumeSlider.java
@@ -1,0 +1,106 @@
+package org.devgeeks.volumeslider;
+
+import android.content.Context;
+import android.media.AudioManager;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.RelativeLayout;
+import android.widget.SeekBar;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaArgs;
+import org.apache.cordova.CordovaPlugin;
+import org.json.JSONException;
+
+public class VolumeSlider extends CordovaPlugin {
+    private SeekBar volumeSeekBar;
+
+    private int cssToViewUnit(double size) {
+        return (int)Math.abs(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, (float)size,
+            cordova.getActivity().getResources().getDisplayMetrics()));
+    }
+
+    @Override
+    public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
+        if (action == null)
+            return false;
+        if (action.equals("createVolumeSlider")) {
+            final int x = cssToViewUnit(args.getDouble(0));
+            final int y = cssToViewUnit(args.getDouble(1));
+            final int width = cssToViewUnit(args.getDouble(2));
+            final int height = cssToViewUnit(args.getDouble(3));
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    createVolumeSlider(x, y, width, height);
+                }
+            });
+            return true;
+        }
+        if (action.equals("showVolumeSlider")) {
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    showVolumeSlider();
+                }
+            });
+            return true;
+        }
+        if (action.equals("hideVolumeSlider")) {
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    hideVolumeSlider();
+                }
+            });
+            return true;
+        }
+        return false;
+    }
+
+    private void bindVolumeSeekBarToAudioManager(SeekBar volumeSeekBar, final Context context)
+    {
+        AudioManager audioManager = (AudioManager)context.getSystemService(Context.AUDIO_SERVICE);
+        volumeSeekBar.setMax(audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC));
+        volumeSeekBar.setProgress(audioManager.getStreamVolume(AudioManager.STREAM_MUSIC));
+
+        volumeSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, progress, 0);
+            }
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {}
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {}
+        });
+    }
+
+    private void createVolumeSlider(int x, int y, int width, int height) {
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(width, height);
+        params.leftMargin = x;
+        params.topMargin = y;
+
+        Context context = cordova.getActivity();
+
+        volumeSeekBar = new SeekBar(context);
+        bindVolumeSeekBarToAudioManager(volumeSeekBar, context);
+        hideVolumeSlider();
+
+        RelativeLayout layout = new RelativeLayout(context);
+        layout.addView(volumeSeekBar, params);
+        ViewGroup container = (ViewGroup)cordova.getActivity().findViewById(android.R.id.content);
+        container.addView(layout);
+    }
+
+    private void showVolumeSlider() {
+        volumeSeekBar.setVisibility(View.VISIBLE);
+    }
+
+    private void hideVolumeSlider() {
+        volumeSeekBar.setVisibility(View.INVISIBLE);
+    }
+
+}

--- a/src/android/VolumeSlider.java
+++ b/src/android/VolumeSlider.java
@@ -15,10 +15,10 @@ import org.json.JSONException;
 import android.util.Log;
 
 public class VolumeSlider extends CordovaPlugin {
-    int current_volume;
     private SeekBar volumeSeekBar;
-    private static final String TAG = "volume_slider";
     private AudioManager audioManager;
+    private static final String TAG = "volume_slider";
+    int current_volume = .2;
 
     private int cssToViewUnit(double size) {
         return (int)Math.abs(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, (float)size,
@@ -111,10 +111,11 @@ public class VolumeSlider extends CordovaPlugin {
 
         volumeSeekBar = new SeekBar(context);
         bindVolumeSeekBarToAudioManager(volumeSeekBar, context);
-
+        
+        // Record current set media volume to revert to
         current_volume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, current_volume, 0);
-        Log.d(TAG, "current_volume=" + current_volume);
+        Log.d(TAG, "current_volume = " + current_volume);
         hideVolumeSlider();
 
         RelativeLayout layout = new RelativeLayout(context);
@@ -133,9 +134,10 @@ public class VolumeSlider extends CordovaPlugin {
 
     private void setVolumeSlider(int volume) {
         Log.d(TAG, "Setting the volume: " + volume );
-        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
+        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, volume*audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
     }
     private void resetVolumeSlider() {
+        // Revert back to initial volume
         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, current_volume, 0);
     }
 }

--- a/src/android/VolumeSlider.java
+++ b/src/android/VolumeSlider.java
@@ -70,7 +70,6 @@ public class VolumeSlider extends CordovaPlugin {
             cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    Log.d(TAG, "DESIRED VOLUME: " + volume);
                     setVolumeSlider(volume);
                 }
             });
@@ -138,13 +137,13 @@ public class VolumeSlider extends CordovaPlugin {
 
     private void setVolumeSlider(double volume) {
         // We map volume to a range of 0.0 - 1.0
-        Log.d(TAG, "SET VOLUME TO: " + (int)(volume * audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)));
+        Log.d(TAG, "SET VOLUME TO: " + volume);
         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, (int)(volume * audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)), 0);
     }
 
     private void resetVolumeSlider() {
         // Resetting back to initial volume
-        Log.d(TAG, "RESET VOLUME TO: " + (int)(current_volume));
+        Log.d(TAG, "RESET VOLUME TO: " + current_volume);
         audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, (int)(current_volume), 0);
     }
 }

--- a/src/ios/VolumeSlider.h
+++ b/src/ios/VolumeSlider.h
@@ -25,7 +25,7 @@
 - (void)createVolumeSlider:(CDVInvokedUrlCommand *)command;
 - (void)showVolumeSlider:(CDVInvokedUrlCommand *)command;
 - (void)hideVolumeSlider:(CDVInvokedUrlCommand *)command;
-- (void)maxVolumeSlider:(CDVInvokedUrlCommand *)command;
+- (void)setVolumeSlider:(CDVInvokedUrlCommand *)command;
 - (void)resetVolumeSlider:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/VolumeSlider.h
+++ b/src/ios/VolumeSlider.h
@@ -25,5 +25,7 @@
 - (void)createVolumeSlider:(CDVInvokedUrlCommand *)command;
 - (void)showVolumeSlider:(CDVInvokedUrlCommand *)command;
 - (void)hideVolumeSlider:(CDVInvokedUrlCommand *)command;
+- (void)maxVolumeSlider:(CDVInvokedUrlCommand *)command;
+- (void)resetVolumeSlider:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/VolumeSlider.m
+++ b/src/ios/VolumeSlider.m
@@ -14,6 +14,9 @@
 
 @synthesize mpVolumeViewParentView, myVolumeView, callbackId;
 
+float userVolume  = 0.2;
+UISlider* volumeViewSlider = nil;
+
 #ifndef __IPHONE_3_0
 @synthesize webView;
 #endif
@@ -30,7 +33,8 @@
 
 - (void) createVolumeSlider:(CDVInvokedUrlCommand *)command
 {
-	NSArray* arguments = [command arguments];
+	NSLog(@"In createVolumeSlider");
+    NSArray* arguments = [command arguments];
     
 	self.callbackId = command.callbackId;
 	NSUInteger argc = [arguments count];
@@ -40,7 +44,7 @@
 	}
 	
 	if (self.mpVolumeViewParentView != NULL) {
-        	return;//already created, don't need to create it again
+       // 	return;//already created, don't need to create it again
 	}
 	
 	CGFloat originx,originy,width;
@@ -68,12 +72,24 @@
 	[[MPVolumeView alloc] initWithFrame: mpVolumeViewParentView.bounds];
 	[mpVolumeViewParentView addSubview: myVolumeView];
 	self.myVolumeView.showsVolumeSlider = NO;
+
+
+    volumeViewSlider = nil;
+    for (UIView *view in [self.myVolumeView subviews]){
+        if ([view.class.description isEqualToString:@"MPVolumeSlider"]){
+            volumeViewSlider = (UISlider*)view;
+            NSLog(@"Found MPVolumeslider :  %f" ,userVolume );
+            break;
+        }
+    }
+
 }
 
 - (void)showVolumeSlider:(CDVInvokedUrlCommand *)command
 {
 	self.myVolumeView.showsVolumeSlider = YES;
 	self.mpVolumeViewParentView.hidden = NO;
+
 }
 
 - (void)hideVolumeSlider:(CDVInvokedUrlCommand *)command
@@ -82,6 +98,22 @@
 	self.myVolumeView.showsVolumeSlider = NO;
 }
 
+- (void)maxVolumeSlider:(CDVInvokedUrlCommand *)command
+{
+    userVolume = volumeViewSlider.value;
+    self.mpVolumeViewParentView.hidden = YES;
+	self.myVolumeView.showsVolumeSlider = NO;
+    [volumeViewSlider setValue:1.0f animated:NO];
+    [volumeViewSlider sendActionsForControlEvents:UIControlEventTouchUpInside];
+
+}
+
+- (void)resetVolumeSlider:(CDVInvokedUrlCommand *)command
+{
+    [volumeViewSlider setValue:userVolume animated:NO];
+    [volumeViewSlider sendActionsForControlEvents:UIControlEventTouchUpInside];
+
+}
 
 
 @end

--- a/src/ios/VolumeSlider.m
+++ b/src/ios/VolumeSlider.m
@@ -82,6 +82,7 @@ UISlider* volumeViewSlider = nil;
             break;
         }
     }
+    userVolume = volumeViewSlider.value;
 
 }
 
@@ -98,12 +99,20 @@ UISlider* volumeViewSlider = nil;
 	self.myVolumeView.showsVolumeSlider = NO;
 }
 
-- (void)maxVolumeSlider:(CDVInvokedUrlCommand *)command
+- (void)setVolumeSlider:(CDVInvokedUrlCommand *)command
 {
-    userVolume = volumeViewSlider.value;
     self.mpVolumeViewParentView.hidden = YES;
 	self.myVolumeView.showsVolumeSlider = NO;
-    [volumeViewSlider setValue:1.0f animated:NO];
+
+	NSArray* arguments = [command arguments];
+	NSUInteger argc = [arguments count];
+
+    if (argc < 1) { // at a minimum we need the value to be set...
+        return;
+    }
+    float setVolume = [[arguments objectAtIndex:0] floatValue];
+
+    [volumeViewSlider setValue:setVolume animated:NO];
     [volumeViewSlider sendActionsForControlEvents:UIControlEventTouchUpInside];
 
 }

--- a/www/VolumeSlider.js
+++ b/www/VolumeSlider.js
@@ -14,7 +14,7 @@ var exec = require('cordova/exec');
 module.exports = {
 
     /**
-	 * Create a volume slider.
+	 * Create a volume slider, and save the user's current set volume.
 	 */
 	createVolumeSlider : function(originx,originy,width,height) {
 		exec(null, null, "VolumeSlider","createVolumeSlider", [originx, originy, width, height]);
@@ -34,14 +34,14 @@ module.exports = {
 	},
 
     /**
-     * Max out the volume slider, and save the user set volume
+     * Set the device's master volume
      */
-    maxVolumeSlider : function() {
-        exec(null, null, "VolumeSlider","maxVolumeSlider", []);
+    setVolumeSlider : function(set_volume) {
+        exec(null, null, "VolumeSlider","setVolumeSlider", [set_volume]);
     },
 
     /**
-     * Reset the volume slider to the original user volume
+     * Reset the volume slider to the original user volume present uon creation of this slider
      */
     resetVolumeSlider : function() {
         exec(null, null, "VolumeSlider","resetVolumeSlider", []);

--- a/www/VolumeSlider.js
+++ b/www/VolumeSlider.js
@@ -34,14 +34,14 @@ module.exports = {
 	},
 
     /**
-     * Hide the volume slider
+     * Max out the volume slider, and save the user set volume
      */
     maxVolumeSlider : function() {
         exec(null, null, "VolumeSlider","maxVolumeSlider", []);
     },
 
     /**
-     * Hide the volume slider
+     * Reset the volume slider to the original user volume
      */
     resetVolumeSlider : function() {
         exec(null, null, "VolumeSlider","resetVolumeSlider", []);

--- a/www/VolumeSlider.js
+++ b/www/VolumeSlider.js
@@ -31,5 +31,19 @@ module.exports = {
 	 */
 	hideVolumeSlider : function() {
 		exec(null, null, "VolumeSlider","hideVolumeSlider", []);
-	}
+	},
+
+    /**
+     * Hide the volume slider
+     */
+    maxVolumeSlider : function() {
+        exec(null, null, "VolumeSlider","maxVolumeSlider", []);
+    },
+
+    /**
+     * Hide the volume slider
+     */
+    resetVolumeSlider : function() {
+        exec(null, null, "VolumeSlider","resetVolumeSlider", []);
+    }
 };


### PR DESCRIPTION
This is a modification to the slider control library to allow you to set the phone's master volume, and then set it back if needed using the clever little slider hack over at - http://stackoverflow.com/questions/19218729/ios-7-mpmusicplayercontroller-volume-deprecated-how-to-change-device-volume-no/24993026#24993026  

Some documenation stuff will need editing, but to use it just do the following : 
volumeSlider = plugins.volumeSlider;
volumeSlider.createVolumeSlider(10, 350, 300, 30); // origin x, origin y, width, height
volumeSlider.setVolumeSlider(1.0); //or w/e you want here, I was just maxing it out. 
volumeSlider.resetVolumeSlider();
